### PR TITLE
Make cluster labels consistent between runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Version 0.8.1 2024-09-18
+## Changes
+- Consistency in cluster labels between runs of the algorithm. If you ran clustering on the same data numerous times,
+  previously the same cluster would likely have had a different label each time. Now there is more stability in the 
+  labelling between runs.
+- Renamed the `default` constructor to `default_hyper_params` and deprecated the former. This is to avoid a name clash
+  with Rust's `Default` trait.
+
 # Version 0.8.0 2024-09-12
 ## Changes
 - Two new distance metrics - Haversine distance for clustering geographical data on the Earth's surface and Cylindrical

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hdbscan"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 authors = [ "Tom Whitehead <t.j.whitehead21@gmail.com>", ]
 description = "HDBSCAN clustering in pure Rust. A huge improvement on DBSCAN, capable of identifying clusters of varying densities."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -646,6 +646,7 @@ impl<'a, T: Float> Hdbscan<'a, T> {
                 self.check_cluster_epsilons(selected_cluster_ids, condensed_tree);
         }
 
+        selected_cluster_ids.sort();
         selected_cluster_ids
     }
 


### PR DESCRIPTION
Consistency in cluster labels between runs of the algorithm. If you ran clustering on the same data numerous times, previously the same cluster would likely have had a different label each time. Now there is more stability in the labelling between runs.