### PR TITLE
Alternative way to get centers when using lat/lon coordinates

### DIFF
--- a/src/centers.rs
+++ b/src/centers.rs
@@ -2,6 +2,7 @@ use num_traits::Float;
 use std::{collections::HashSet, ops::AddAssign};
 
 /// Possible methodologies for calculating the center of clusters
+#[derive(Debug, PartialEq)]
 pub enum Center {
     /// The elementwise mean of all data points in a cluster.
     /// The output is not guaranteed to be an observed data point.

--- a/src/centers.rs
+++ b/src/centers.rs
@@ -1,17 +1,26 @@
 use num_traits::Float;
-use std::collections::HashSet;
+use std::{collections::HashSet, ops::AddAssign};
 
 /// Possible methodologies for calculating the center of clusters
 pub enum Center {
     /// The elementwise mean of all data points in a cluster.
     /// The output is not guaranteed to be an observed data point.
     Centroid,
+    /// Calculates the geographical center of gravity for lat/lon coordinates.
+    /// Assumes input coordinates are in degrees (latitude, longitude).
+    /// Output coordinates are also in degrees.
+    GeoCenterOfGravity,
 }
 
 impl Center {
-    pub(crate) fn calc_centers<T: Float>(&self, data: &[Vec<T>], labels: &[i32]) -> Vec<Vec<T>> {
+    pub(crate) fn calc_centers<T: Float + AddAssign>(
+        &self,
+        data: &[Vec<T>],
+        labels: &[i32],
+    ) -> Vec<Vec<T>> {
         match self {
             Center::Centroid => self.calc_centroids(data, labels),
+            Center::GeoCenterOfGravity => self.centers_of_gravity(data, labels),
         }
     }
 
@@ -53,5 +62,70 @@ impl Center {
             centroids.push(element_wise_mean);
         }
         centroids
+    }
+
+    /// Calculates the geographical center of gravity for each cluster.
+    ///
+    /// This method is specifically designed for geographical data where each point
+    /// is represented by latitude and longitude coordinates.
+    ///
+    /// # Arguments
+    ///
+    /// * `data` - A slice of vectors, where each vector contains [latitude, longitude] in degrees.
+    /// * `labels` - A slice of cluster labels corresponding to each data point.
+    ///
+    /// # Returns
+    ///
+    /// A vector of cluster centers, where each center is a vector of [latitude, longitude] in degrees.
+    ///
+    /// # Notes
+    ///
+    /// - Assumes input coordinates are in degrees.
+    /// - Output coordinates are in degrees.
+    /// - Points with label -1 are considered noise and are ignored in calculations.
+    /// - Uses a spherical approximation of the Earth for calculations.
+    fn centers_of_gravity<T: Float + AddAssign>(
+        &self,
+        data: &[Vec<T>],
+        labels: &[i32],
+    ) -> Vec<Vec<T>> {
+        let n_clusters = labels
+            .iter()
+            .filter(|&&label| label != -1)
+            .collect::<HashSet<_>>()
+            .len();
+        let mut centers = vec![vec![T::zero(), T::zero()]; n_clusters];
+        let mut counts = vec![T::zero(); n_clusters];
+
+        for (point, &label) in data.iter().zip(labels.iter()) {
+            if label != -1 {
+                let cluster_index = label as usize;
+                centers[cluster_index][0] += point[0].to_radians();
+                centers[cluster_index][1] += point[1].to_radians();
+                counts[cluster_index] += T::one();
+            }
+        }
+
+        // Calculate final center of gravity for each cluster
+        for (center, &count) in centers.iter_mut().zip(counts.iter()) {
+            if count > T::zero() {
+                let avg_lat = center[0] / count;
+                let avg_lon = center[1] / count;
+
+                let x = avg_lon.cos() * avg_lat.cos();
+                let y = avg_lon.sin() * avg_lat.cos();
+                let z = avg_lat.sin();
+
+                let lon = y.atan2(x);
+                let hyp = (x * x + y * y).sqrt();
+                let lat = z.atan2(hyp);
+
+                // Convert back to degrees
+                center[0] = lat.to_degrees();
+                center[1] = lon.to_degrees();
+            }
+        }
+
+        centers
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -259,6 +259,14 @@ impl<'a, T: Float + AddAssign> Hdbscan<'a, T> {
         labels: &[i32],
     ) -> Result<Vec<Vec<T>>, HdbscanError> {
         assert_eq!(labels.len(), self.data.len());
+        if self.hp.dist_metric != DistanceMetric::Haversine
+            && center == Center::GeoCenterOfGravity
+        {
+            // TODO: Implement a more appropriate error variant when doing a major version bump
+            return Err(HdbscanError::WrongDimension(String::from(
+                "Geographical centroids can only be used with geographical coordinates."
+            )));
+        }
         Ok(center.calc_centers(self.data, labels))
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -259,12 +259,11 @@ impl<'a, T: Float + AddAssign> Hdbscan<'a, T> {
         labels: &[i32],
     ) -> Result<Vec<Vec<T>>, HdbscanError> {
         assert_eq!(labels.len(), self.data.len());
-        if self.hp.dist_metric != DistanceMetric::Haversine
-            && center == Center::GeoCenterOfGravity
+        if self.hp.dist_metric != DistanceMetric::Haversine && center == Center::GeoCenterOfGravity
         {
             // TODO: Implement a more appropriate error variant when doing a major version bump
             return Err(HdbscanError::WrongDimension(String::from(
-                "Geographical centroids can only be used with geographical coordinates."
+                "Geographical centroids can only be used with geographical coordinates.",
             )));
         }
         Ok(center.calc_centers(self.data, labels))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@ use crate::union_find::UnionFind;
 use num_traits::Float;
 use std::collections::{HashMap, VecDeque};
 use std::f64::consts::PI;
+use std::ops::AddAssign;
 
 pub use crate::centers::Center;
 pub use crate::core_distances::NnAlgorithm;
@@ -82,7 +83,7 @@ pub struct Hdbscan<'a, T> {
     hp: HdbscanHyperParams,
 }
 
-impl<'a, T: Float> Hdbscan<'a, T> {
+impl<'a, T: Float + AddAssign> Hdbscan<'a, T> {
     /// Creates an instance of HDBSCAN clustering model using a custom hyper parameter
     /// configuration.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,6 @@ use crate::union_find::UnionFind;
 use num_traits::Float;
 use std::collections::{HashMap, VecDeque};
 use std::f64::consts::PI;
-use std::ops::AddAssign;
 
 pub use crate::centers::Center;
 pub use crate::core_distances::NnAlgorithm;
@@ -83,7 +82,7 @@ pub struct Hdbscan<'a, T> {
     hp: HdbscanHyperParams,
 }
 
-impl<'a, T: Float + AddAssign> Hdbscan<'a, T> {
+impl<'a, T: Float> Hdbscan<'a, T> {
     /// Creates an instance of HDBSCAN clustering model using a custom hyper parameter
     /// configuration.
     ///
@@ -259,8 +258,7 @@ impl<'a, T: Float + AddAssign> Hdbscan<'a, T> {
         labels: &[i32],
     ) -> Result<Vec<Vec<T>>, HdbscanError> {
         assert_eq!(labels.len(), self.data.len());
-        if self.hp.dist_metric != DistanceMetric::Haversine && center == Center::GeoCenterOfGravity
-        {
+        if self.hp.dist_metric != DistanceMetric::Haversine && center == Center::GeoCentroid {
             // TODO: Implement a more appropriate error variant when doing a major version bump
             return Err(HdbscanError::WrongDimension(String::from(
                 "Geographical centroids can only be used with geographical coordinates.",


### PR DESCRIPTION
Summary
----
I'm opening this as a draft since I could use some input. When doing clustering with lat/lon coordinates, I wonder whether adding an alternative way to calculate centers would make sense? For now I just call it center-of-gravity, even though it doesn't really mean that, can rename to something more meaningful perhaps.

I'll try to add some tests for this, but in my limited local testing this seems to give decent centers.

Maybe there's a better algorithm to do this? Open to any suggestions. Thanks!