### PR TITLE
Add an intentionally failing test

### DIFF
--- a/src/core_distances.rs
+++ b/src/core_distances.rs
@@ -32,14 +32,14 @@ impl CoreDistance for BruteForce {
     ) -> Vec<T> {
         let n_samples = data.len();
         let dist_matrix = calc_pairwise_distances(data, distance::get_dist_func(&dist_metric));
-        println!("+++M4 dist_matrix: {:?}", dist_matrix);
+        println!("+++M6 dist_matrix: {:?}", dist_matrix);
         let mut core_distances = Vec::with_capacity(n_samples);
 
         for mut distances in dist_matrix.into_iter().take(n_samples) {
             distances.sort_by(|a, b| a.partial_cmp(b).expect("Invalid float"));
             core_distances.push(distances[k - 1]);
         }
-        println!("+++M5 core_distances: {:?}", core_distances);
+        println!("+++M7 core_distances: {:?}", core_distances);
 
         core_distances
     }

--- a/src/core_distances.rs
+++ b/src/core_distances.rs
@@ -1,5 +1,6 @@
 use crate::{distance, DistanceMetric};
 use num_traits::Float;
+use std::fmt::Debug;
 
 /// The nearest neighbour algorithm options
 #[derive(Debug, Clone, PartialEq)]
@@ -14,7 +15,7 @@ pub enum NnAlgorithm {
 }
 
 pub(crate) trait CoreDistance {
-    fn calc_core_distances<T: Float>(
+    fn calc_core_distances<T: Float + Debug>(
         data: &[Vec<T>],
         k: usize,
         dist_metric: DistanceMetric,
@@ -24,19 +25,21 @@ pub(crate) trait CoreDistance {
 pub(crate) struct BruteForce;
 
 impl CoreDistance for BruteForce {
-    fn calc_core_distances<T: Float>(
+    fn calc_core_distances<T: Float + Debug>(
         data: &[Vec<T>],
         k: usize,
         dist_metric: DistanceMetric,
     ) -> Vec<T> {
         let n_samples = data.len();
         let dist_matrix = calc_pairwise_distances(data, distance::get_dist_func(&dist_metric));
+        println!("+++M4 dist_matrix: {:?}", dist_matrix);
         let mut core_distances = Vec::with_capacity(n_samples);
 
         for mut distances in dist_matrix.into_iter().take(n_samples) {
             distances.sort_by(|a, b| a.partial_cmp(b).expect("Invalid float"));
             core_distances.push(distances[k - 1]);
         }
+        println!("+++M5 core_distances: {:?}", core_distances);
 
         core_distances
     }

--- a/src/data_wrappers.rs
+++ b/src/data_wrappers.rs
@@ -12,6 +12,7 @@ pub(crate) struct SLTNode<T> {
     pub(crate) size: usize,
 }
 
+#[derive(Debug)]
 pub(crate) struct CondensedNode<T> {
     pub(crate) node_id: usize,
     pub(crate) parent_node_id: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1075,4 +1075,33 @@ mod tests {
         // The final red point is noise
         assert_eq!(-1, result[6]);
     }
+
+    #[test]
+    fn test_failing_haversine_cluster() {
+        let data = vec![
+            vec![25.948000303675823, -80.14385839372238],
+            vec![25.94805667998456, -80.145566657281],
+            vec![25.9458914986468, -80.16442455966394],
+            vec![26.0070633, -80.158535],
+        ];
+
+        let hyper_params = HdbscanHyperParams::builder()
+            .allow_single_cluster(true)
+            .min_cluster_size(2)
+            .min_samples(1)
+            .dist_metric(DistanceMetric::Haversine)
+            // 5000m to consider separate cluster
+            .epsilon(5000.0)
+            .nn_algorithm(NnAlgorithm::BruteForce)
+            .build();
+
+        let clusterer = Hdbscan::new(&data, hyper_params);
+        let result = clusterer.cluster().unwrap();
+
+        let noise_count = result.iter().filter(|&&x| x == -1).count();
+        println!("noise_count: {}", noise_count);
+
+        // Check that we only 1 noise point
+        assert_eq!(noise_count, 1, "Should have 1 noise point");
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,7 +212,9 @@ impl<'a, T: Float + Debug> Hdbscan<'a, T> {
         let min_spanning_tree = self.prims_min_spanning_tree(&core_distances);
         let single_linkage_tree = self.make_single_linkage_tree(&min_spanning_tree);
         let condensed_tree = self.condense_tree(&single_linkage_tree);
+        println!("+++M8 condensed_tree: {:#?}", condensed_tree);
         let winning_clusters = self.extract_winning_clusters(&condensed_tree);
+        println!("+++M9 winning_clusters: {:?}", winning_clusters);
         let labelled_data = self.label_data(&winning_clusters, &condensed_tree);
         Ok(labelled_data)
     }
@@ -359,6 +361,8 @@ impl<'a, T: Float + Debug> Hdbscan<'a, T> {
     {
         let (data, k, dist_metric) = (self.data, self.hp.min_samples, self.hp.dist_metric);
         println!("+++M3 dist_metric: {:?}", dist_metric);
+        println!("+++M4 k: {:?}", k);
+        println!("+++M5 data: {:?}", k);
 
         match (&self.hp.nn_algo, self.n_samples) {
             (NnAlgorithm::Auto, usize::MIN..=BRUTE_FORCE_N_SAMPLES_LIMIT) => {
@@ -617,6 +621,7 @@ impl<'a, T: Float + Debug> Hdbscan<'a, T> {
     fn extract_winning_clusters(&self, condensed_tree: &CondensedTree<T>) -> Vec<usize> {
         let n_clusters = self.calc_num_clusters(condensed_tree);
         let mut stabilities = self.calc_all_stabilities(n_clusters, condensed_tree);
+        println!("+++M10 stabilities: {:?}", stabilities);
         let mut clusters: HashMap<usize, bool> =
             stabilities.keys().map(|id| (*id, false)).collect();
 
@@ -683,6 +688,7 @@ impl<'a, T: Float + Debug> Hdbscan<'a, T> {
 
     fn calc_stability(&self, cluster_id: usize, condensed_tree: &CondensedTree<T>) -> T {
         let lambda_birth = self.extract_lambda_birth(cluster_id, condensed_tree);
+        println!("+++M11 lambda_birth: {:?}", lambda_birth);
         condensed_tree
             .iter()
             .filter(|node| node.parent_node_id == cluster_id)
@@ -691,6 +697,10 @@ impl<'a, T: Float + Debug> Hdbscan<'a, T> {
     }
 
     fn extract_lambda_birth(&self, cluster_id: usize, condensed_tree: &CondensedTree<T>) -> T {
+        println!(
+            "+++M12 cluster_id: {:?}, n_samples: {:?}",
+            cluster_id, self.n_samples
+        );
         if self.is_top_cluster(&cluster_id) {
             T::zero()
         } else {
@@ -1095,7 +1105,7 @@ mod tests {
         let hyper_params = HdbscanHyperParams::builder()
             .allow_single_cluster(true)
             .min_cluster_size(2)
-            .min_samples(1)
+            .min_samples(2)
             .dist_metric(DistanceMetric::Haversine)
             // 5000m to consider separate cluster
             .epsilon(5000.0)


### PR DESCRIPTION
Summary
----
Hi @tom-whitehead, I have added an intentionally failing test for clustering when using lat/lon with haversine distances.
I'm trying to figure it out but could use an extra set of eyes if you wouldn't mind.

My expectation here is that there should be one cluster with three sets of points (label:  `0`) and one point which should be considered noise (label: `-1`) but instead we get all four points classified as noise, each with label = -1. I'd appreciate if you could give me some pointers on how to debug this further. Thanks!