### PR TITLE
Simplify error handling a bit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ categories = ["algorithms", "mathematics", "science"]
 [dependencies]
 num-traits = "0.2.18"
 kdtree = "0.7.0"
+thiserror = "1"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,25 +1,14 @@
-use std::error::Error;
-use std::fmt::{Display, Formatter};
+use thiserror::Error;
 
 /// Possible errors that arise due to issues with HDBSCAN input data.
-#[derive(Debug, Clone)]
+#[derive(Error, Debug)]
 pub enum HdbscanError {
+    #[error("Could not find node")]
+    NodeNotFound,
+    #[error("The dataset provided is empty")]
     EmptyDataset,
+    #[error("Input vectors have mismatched dimensions {0}")]
     WrongDimension(String),
+    #[error("Non finite coordinates: {0}")]
     NonFiniteCoordinate(String),
-}
-
-impl Error for HdbscanError {}
-
-impl Display for HdbscanError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let message = match self {
-            HdbscanError::EmptyDataset => String::from("The dataset provided is empty"),
-            HdbscanError::WrongDimension(msg) => {
-                format!("Input vectors have mismatched dimensions: {msg}")
-            }
-            HdbscanError::NonFiniteCoordinate(msg) => format!("Non finite coordinate: {msg}"),
-        };
-        write!(f, "{message}")
-    }
 }


### PR DESCRIPTION
Summary
----
Rather than crashing because of an `expect` statement in the code, I have added `thiserror` library and simplified a bit of error handling so the callers can handle it a bit more gracefully.

NOTE: There's more occurrences of `expect` statement being used throughout. I have only replaced one which I found happening more often in my project. A more thorough handling of errors is probably wiser in the long term.