### PR TITLE
Add clustering from precalculated distance matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Version 0.10.0 2024-11-13
+## Changes
+- Added the ability to cluster from a precomputed distance matrix. This is useful when you have a distance matrix 
+  calculated from a different source and you want to cluster the data based on that matrix. This can be done by 
+  specifying `DistanceMetric::Precalculated` hyper parameter and providing the distance matrix as a 2D vector to 
+  `Hdbscan::new`.
+
 # Version 0.9.0 2024-11-13
 ## Changes
 - Added `Center::Medoid` as a means of calculating the center of clusters. The medoid is the point in a cluster with 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hdbscan"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 authors = [ "Tom Whitehead <t.j.whitehead21@gmail.com>", ]
 description = "HDBSCAN clustering in pure Rust. A huge improvement on DBSCAN, capable of identifying clusters of varying densities."

--- a/src/core_distances.rs
+++ b/src/core_distances.rs
@@ -29,16 +29,8 @@ impl CoreDistance for BruteForce {
         k: usize,
         dist_metric: DistanceMetric,
     ) -> Vec<T> {
-        let n_samples = data.len();
         let dist_matrix = calc_pairwise_distances(data, distance::get_dist_func(&dist_metric));
-        let mut core_distances = Vec::with_capacity(n_samples);
-
-        for mut distances in dist_matrix.into_iter().take(n_samples) {
-            distances.sort_by(|a, b| a.partial_cmp(b).expect("Invalid float"));
-            core_distances.push(distances[k - 1]);
-        }
-
-        core_distances
+        get_core_distances_from_matrix(&dist_matrix, k)
     }
 }
 
@@ -58,6 +50,19 @@ where
         }
     }
     dist_matrix
+}
+
+pub(crate) fn get_core_distances_from_matrix<T: Float>(dist_matrix: &[Vec<T>], k: usize) -> Vec<T> {
+    let n_samples = dist_matrix.len();
+    let mut core_distances = Vec::with_capacity(n_samples);
+
+    for distances in dist_matrix.iter().take(n_samples) {
+        let mut distances = distances.clone();
+        distances.sort_by(|a, b| a.partial_cmp(b).expect("Invalid float"));
+        core_distances.push(distances[k - 1]);
+    }
+
+    core_distances
 }
 
 pub(crate) struct KdTree;

--- a/src/distance.rs
+++ b/src/distance.rs
@@ -21,6 +21,9 @@ pub enum DistanceMetric {
     /// The sum of all absolute differences between each dimension of two points.
     /// Also known as L1 norm or city block.
     Manhattan,
+    /// Pre-calculated distance metric between the points is provided as `data` parameter
+    /// to the HDBSCAN constructor
+    Precalculated,
 }
 
 impl DistanceMetric {
@@ -31,6 +34,7 @@ impl DistanceMetric {
             Self::Euclidean => euclidean_distance(a, b),
             Self::Haversine => haversine_distance(a, b),
             Self::Manhattan => manhattan_distance(a, b),
+            Self::Precalculated => panic!("Precalculated distance metric should not be used here"),
         }
     }
 }
@@ -42,6 +46,9 @@ pub(crate) fn get_dist_func<T: Float>(metric: &DistanceMetric) -> impl Fn(&[T], 
         DistanceMetric::Euclidean => euclidean_distance,
         DistanceMetric::Haversine => haversine_distance,
         DistanceMetric::Manhattan => manhattan_distance,
+        DistanceMetric::Precalculated => {
+            panic!("Precalculated distance metric should not be used here")
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,7 @@ impl<'a, T: Float> Hdbscan<'a, T> {
         since = "0.8.1",
         note = "Please use `default_hyper_params` constructor instead"
     )]
-    pub fn default(data: &'a [Vec<T>]) -> Hdbscan<T> {
+    pub fn default(data: &'a [Vec<T>]) -> Hdbscan<'a, T> {
         let hyper_params = HdbscanHyperParams::default();
         Hdbscan::new(data, hyper_params)
     }
@@ -162,7 +162,7 @@ impl<'a, T: Float> Hdbscan<'a, T> {
     ///];
     ///let clusterer = Hdbscan::default_hyper_params(&data);
     /// ```
-    pub fn default_hyper_params(data: &'a [Vec<T>]) -> Hdbscan<T> {
+    pub fn default_hyper_params(data: &'a [Vec<T>]) -> Hdbscan<'a, T> {
         let hyper_params = HdbscanHyperParams::default();
         Hdbscan::new(data, hyper_params)
     }
@@ -755,7 +755,7 @@ impl<'a, T: Float> Hdbscan<'a, T> {
         &'b self,
         cluster_id: usize,
         condensed_tree: &'b CondensedTree<T>,
-    ) -> Vec<&CondensedNode<T>> {
+    ) -> Vec<&'b CondensedNode<T>> {
         condensed_tree
             .iter()
             .filter(|node| node.parent_node_id == cluster_id)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -379,7 +379,7 @@ impl<'a, T: Float> Hdbscan<'a, T> {
         if self.data.iter().any(|row| row.len() != self.n_samples) {
             return false;
         }
-        for i in 0.. self.n_samples {
+        for i in 0..self.n_samples {
             for j in 0..self.n_samples {
                 if (self.data[i][j] - self.data[j][i]).abs() > T::epsilon() {
                     return false;


### PR DESCRIPTION
# Summary 
Added the ability to cluster from a precomputed distance matrix, without the need of specifying a specific distance metric or or providing the original vectors.